### PR TITLE
patch for opencv version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,12 @@ project(${PROJECT_NAME})
 
 find_package(OpenCV REQUIRED)
 
-MESSAGE ( STATUS " OpenCV libs: " ${OpenCV_LIBS} )
-MESSAGE ( STATUS " OpenCV includes: " ${OpenCV_INCLUDE_DIRS} )
+if(OpenCV_VERSION VERSION_GREATER "3.0")
+    MESSAGE( FATAL_ERROR "OpenCV < 4.0 is REQUIRED" )
+else()
+    MESSAGE ( STATUS " OpenCV libs: " ${OpenCV_LIBS} )
+    MESSAGE ( STATUS " OpenCV includes: " ${OpenCV_INCLUDE_DIRS} )
+endif()
 
 include_directories(${OPENCV_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
the previous version did not work with the newer version of opencv. i put a little check to stop the cmake execution. not the best solution ever, but at least gives some hint.

otherwise you could rearrange the code with something like .. 

```
#if (CV_VERSION_MAJOR >= 4)
    cv::cvtColor(matref, matref, cv::COLOR_BGR2RGB);
 #else
    cv::cvtColor(matref, matref, CV_BGR2RGB);
 #endif
```